### PR TITLE
decouple flushing from flag evaluation

### DIFF
--- a/AzureFunction.VstsExtension.LaunchDarkly/AzureFunction.VstsExtension.LaunchDarkly/AzureFunctions/GetUserFeatureFlag.cs
+++ b/AzureFunction.VstsExtension.LaunchDarkly/AzureFunction.VstsExtension.LaunchDarkly/AzureFunctions/GetUserFeatureFlag.cs
@@ -28,6 +28,8 @@ namespace AzureFunction.VstsExtension.LaunchDarkly
         {
             try
             {
+                Task<HttpResponseMessage> response = null;
+
                 telemetry.Context.Operation.Id = context.InvocationId.ToString();
                 telemetry.Context.Operation.Name = "GetUserFeatureFlag";
                 var startTime = DateTime.Now;
@@ -75,19 +77,21 @@ namespace AzureFunction.VstsExtension.LaunchDarkly
                     }
                     if (userFlags != null)
                     {
-                        return req.CreateResponse(HttpStatusCode.OK, userFlags); //return the users flags
+                        response = req.CreateResponse(HttpStatusCode.OK, userFlags); //return the users flags
                     }
                     else
                     {
                         telemetry.TrackTrace("flags is null");
-                        return req.CreateResponse(HttpStatusCode.InternalServerError, "User flags is null");
+                        response = req.CreateResponse(HttpStatusCode.InternalServerError, "User flags is null");
                     }
+                    _ldclient.flush();
                 }
                 else
                 {
                     telemetry.TrackTrace("The token is not valid");
-                    return req.CreateResponse(HttpStatusCode.Unauthorized, "The token is not valid");
+                    response = req.CreateResponse(HttpStatusCode.Unauthorized, "The token is not valid");
                 }
+                return response;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Changes proposed in this pull request:  
- Allows response to be created (and I assume sent) before flushing LaunchDarkly events
- Reduce the number of return statements for code clarity

If calling HttpRequestMessage.CreateResponse actually sends the response, and it is not sent after the Run method completes and returns theHttpRequestMessage, then waiting until after this method is called to flush will result in a faster response to your users.

